### PR TITLE
Center window horizontally

### DIFF
--- a/assets/main.qml
+++ b/assets/main.qml
@@ -2,6 +2,7 @@ import QtQuick 2.5
 import QtQuick.Controls 1.3
 import QtQuick.Layouts 1.2
 import QtQuick.Controls.Styles 1.4
+import QtQuick.Window 2.2
 
 ApplicationWindow {
     id: rootWindow
@@ -12,6 +13,8 @@ ApplicationWindow {
     height: mainLayout.implicitHeight + 2 * margin
     minimumWidth: mainLayout.Layout.minimumWidth + 2 * margin
     minimumHeight: 300
+
+    x: (Screen.width - width) / 2
 
     flags: Qt.FramelessWindowHint | Qt.Window
     color: "transparent"


### PR DESCRIPTION
GoPass seems like a nice little application. However, especially seeing its purpose, having it open on the top-left of the screen just feels... wrong. I would much rather see it centered horizontally on the screen, just like KRunner.

This small patch ensures this centering. I have not tested this on a multi-monitor setup, as I only have a single monitor, but [reading the Qt documentation](https://doc.qt.io/qt-5/qml-qtquick-window-screen.html#width-attached-prop) Screen.width only seems to grab the width of the current screen.
