### PR TITLE
Index update

### DIFF
--- a/assets/main.qml
+++ b/assets/main.qml
@@ -20,12 +20,7 @@ ApplicationWindow {
 
     MouseArea {
         id: mouseRegion
-        property variant clickPos: "1,1"
-        anchors.rightMargin: 0
-        anchors.bottomMargin: 0
-        anchors.leftMargin: 0
-        anchors.topMargin: 0
-
+        property var clickPos: "1, 1"
         anchors.fill: parent;
 
         onPressed: {
@@ -44,10 +39,6 @@ ApplicationWindow {
 
         color: "#333"
         radius: 10
-        anchors.rightMargin: 0
-        anchors.bottomMargin: 0
-        anchors.leftMargin: 0
-        anchors.topMargin: 0
         anchors.fill: parent
         border.width: 2
         border.color: "#aaa"

--- a/assets/main.qml
+++ b/assets/main.qml
@@ -326,7 +326,7 @@ ApplicationWindow {
                 property var view: ListView.view
                 property int itemIndex: index
 
-                text: passwords.get(index).name;
+                text: passwords.get(index);
                 font.pixelSize: 18
                 color: ListView.isCurrentItem? "#dd00bb":"gray"
 

--- a/keyinfo.go
+++ b/keyinfo.go
@@ -67,11 +67,6 @@ func parseKeyinfo(statusLine string) GPGAgentKeyInfo {
 	}
 }
 
-func (p *Password) isCached() bool {
-	ki := p.KeyInfo()
-	return ki.Cached
-}
-
 var algoNames map[packet.PublicKeyAlgorithm]string
 
 func init() {
@@ -91,11 +86,11 @@ func algoString(a packet.PublicKeyAlgorithm) string {
 }
 
 // KeyInfo gets the KeyInfo for this password
-func (p *Password) KeyInfo() KeyInfo {
+func keyInfo(path string) KeyInfo {
 	gpgmeMutex.Lock()
 	defer gpgmeMutex.Unlock()
 	// Find the keyID for the encrypted data
-	encKeyID := findKey(p.Path)
+	encKeyID := findKey(path)
 
 	// Extract key from gpgme
 	c, _ := gpgme.New()

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ type Passwords struct {
 	Selected int
 	Len      int
 	store    *PasswordStore
-	hits     []Password
+	hits     []string
 }
 
 // Quit the application
@@ -55,13 +55,13 @@ func (ui *UI) ToggleShowMetadata() {
 }
 
 // Get gets the password at a specific index
-func (p *Passwords) Get(index int) Password {
+func (p *Passwords) Get(index int) string {
 	if index > len(p.hits) {
 		fmt.Println("Bad password fetch", index, len(p.hits), p.Len)
-		return Password{}
+		return ""
 	}
 	pw := p.hits[index]
-	return pw
+	return p.store.passwords[pw]
 }
 
 // ClearClipboard clears the clipboard
@@ -101,8 +101,7 @@ func (p *Passwords) CopyToClipboard(selected int) {
 		ui.setStatus("No password selected")
 		return
 	}
-	pw := (p.hits)[selected]
-	pass := pw.Password()
+	pass := Password(p.hits[selected])
 	if err := clipboard.WriteAll(pass); err != nil {
 		panic(err)
 	}
@@ -143,12 +142,12 @@ func (p *Passwords) Update(status string) {
 	p.hits = p.store.Query(ui.query)
 	p.Len = len(p.hits)
 
-	var pw Password
+	var pw string
 
 	ui.Password.Info = "Test"
 	if p.Selected < p.Len {
 		pw = (p.hits)[p.Selected]
-		ki := pw.KeyInfo()
+		ki := keyInfo(pw)
 		if ki.Algorithm != "" {
 			ui.Password.Info = fmt.Sprintf("Encrypted with %d bit %s key %s",
 				ki.BitLength, ki.Algorithm, ki.Fingerprint)
@@ -157,14 +156,14 @@ func (p *Passwords) Update(status string) {
 			ui.Password.Info = "Not encrypted"
 			ui.Password.Cached = false
 		}
-		ui.Password.Name = pw.Name
+		ui.Password.Name = p.store.passwords[pw]
 	}
 
 	if ui.ShowMetadata {
-		ui.Password.Metadata = pw.Metadata()
+		ui.Password.Metadata = Metadata(pw)
 	} else {
 		ui.Password.Metadata = "Press enter to decrypt"
-		ui.Password.Metadata = pw.Raw()
+		ui.Password.Metadata = Raw(pw)
 	}
 	qml.Changed(p, &p.Len)
 	qml.Changed(&ui, &ui.Password)
@@ -177,12 +176,11 @@ func (p *Passwords) Update(status string) {
 
 var ui UI
 var passwords Passwords
-var ps *PasswordStore
 
 func main() {
-	ps = NewPasswordStore()
-	passwords.store = ps
+	ps := NewPasswordStore()
 	ps.Subscribe(passwords.Update)
+	passwords.store = ps
 	passwords.Update("Started")
 	if err := qml.Run(run); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func (p *Passwords) Select(selected int) {
 // Query updates the hitlist with the given query
 func (ui *UI) Query(q string) {
 	ui.query = q
-	passwords.Update("queried")
+	passwords.Update("Queried")
 }
 
 func (ui *UI) setStatus(s string) {
@@ -170,7 +170,9 @@ func (p *Passwords) Update(status string) {
 	qml.Changed(&ui, &ui.Password)
 	qml.Changed(&ui, &ui.Password.Metadata)
 	qml.Changed(&ui, &ui.Password.Name)
-	ui.setStatus(status)
+	if status != "" {
+		ui.setStatus(status)
+	}
 }
 
 var ui UI


### PR DESCRIPTION
Fix the problem of replicated entries when updating items in the password store. With this PR, we perform the minimum operation required per type of update, i.e.:
- Add a single entry when a new password is added to the store
- Remove a single entry when a password is removed from the store
- Re-index everything when a password is moved
- Do nothing when when a password is updated

In addition, this PR also tries to make the UI updates displayed in the lower left corner more consistent and durable (before, most of them where overwritten with an empty message right after being published, so they were not visible). 