### PR TITLE
Clear clipboard fix (Issue #28)

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,6 +183,7 @@ var passwords Passwords
 var ps *PasswordStore
 
 func main() {
+	ui.countdownDone = make(chan bool)
 	ps = NewPasswordStore()
 	passwords.store = ps
 	ps.Subscribe(passwords.Update)

--- a/main.go
+++ b/main.go
@@ -102,7 +102,12 @@ func (p *Passwords) CopyToClipboard(selected int) {
 		return
 	}
 	pw := (p.hits)[selected]
-	pass := pw.Password()
+	pass, err := pw.Password()
+	if err != nil {
+		ui.setStatus("Cancelled")
+		return
+	}
+
 	if err := clipboard.WriteAll(pass); err != nil {
 		panic(err)
 	}

--- a/pass.go
+++ b/pass.go
@@ -59,11 +59,14 @@ func (p *Password) Metadata() string {
 	return metadata
 }
 
-func (p *Password) Password() string {
-	decrypted, _ := p.decrypt()
+func (p *Password) Password() (string, error) {
+	decrypted, err := p.decrypt()
+	if err != nil {
+		return "", err
+	}
 	nr := bufio.NewReader(decrypted)
 	password, _ := nr.ReadString('\n')
-	return password
+	return password, nil
 }
 
 // NewPasswordStore creates a new password store


### PR DESCRIPTION
Fix the bugs described in issue #28 and eliminate potential race condition. The logic for the countdown has been enhanced and simplified, and the number of goroutines that can be spawned for the clipboard countdown is now limited to exactly one.